### PR TITLE
命名規約に従って各種リソースの名前を設定できるように修正 and その他軽微な機能追加と修正

### DIFF
--- a/bin/monitoring-snapmirror-relationship-health.ts
+++ b/bin/monitoring-snapmirror-relationship-health.ts
@@ -4,11 +4,17 @@ import * as cdk from "aws-cdk-lib";
 import { MonitoringSnapMirrorRelationshipHealthStack } from "../lib/monitoring-snapmirror-relationship-health-stack";
 import { monitoringSnapMirrorRelationshipHealthStackProperty } from "../parameter/index";
 
+const stackName = monitoringSnapMirrorRelationshipHealthStackProperty.props
+  .systemProperty
+  ? `${monitoringSnapMirrorRelationshipHealthStackProperty.props.systemProperty.systemName}-${monitoringSnapMirrorRelationshipHealthStackProperty.props.systemProperty.envName}-stack-monitoring-snapmirror-health`
+  : "FsxnResourcesStack";
+
 const app = new cdk.App();
 const stack = new MonitoringSnapMirrorRelationshipHealthStack(
   app,
   "MonitoringSnapmirrorRelationshipHealthStack",
   {
+    stackName,
     env: monitoringSnapMirrorRelationshipHealthStackProperty.env,
     ...monitoringSnapMirrorRelationshipHealthStackProperty.props,
   }

--- a/bin/monitoring-snapmirror-relationship-health.ts
+++ b/bin/monitoring-snapmirror-relationship-health.ts
@@ -5,7 +5,7 @@ import { MonitoringSnapMirrorRelationshipHealthStack } from "../lib/monitoring-s
 import { monitoringSnapMirrorRelationshipHealthStackProperty } from "../parameter/index";
 
 const app = new cdk.App();
-new MonitoringSnapMirrorRelationshipHealthStack(
+const stack = new MonitoringSnapMirrorRelationshipHealthStack(
   app,
   "MonitoringSnapmirrorRelationshipHealthStack",
   {
@@ -13,3 +13,7 @@ new MonitoringSnapMirrorRelationshipHealthStack(
     ...monitoringSnapMirrorRelationshipHealthStackProperty.props,
   }
 );
+
+monitoringSnapMirrorRelationshipHealthStackProperty.tags?.forEach((tag) => {
+  cdk.Tags.of(stack).add(tag.key, tag.value);
+});

--- a/bin/monitoring-snapmirror-relationship-health.ts
+++ b/bin/monitoring-snapmirror-relationship-health.ts
@@ -17,6 +17,7 @@ const stack = new MonitoringSnapMirrorRelationshipHealthStack(
     stackName,
     env: monitoringSnapMirrorRelationshipHealthStackProperty.env,
     ...monitoringSnapMirrorRelationshipHealthStackProperty.props,
+    terminationProtection: true,
   }
 );
 

--- a/lib/construct/base-construct.ts
+++ b/lib/construct/base-construct.ts
@@ -1,0 +1,85 @@
+import { Construct } from "constructs";
+import { SystemProperty } from "../../parameter";
+
+export interface BaseConstructProps {
+  systemProperty?: SystemProperty;
+}
+
+export class BaseConstruct extends Construct {
+  private readonly props: Readonly<BaseConstructProps>;
+  constructor(scope: Construct, id: string, props: BaseConstructProps) {
+    super(scope, id);
+
+    this.props = Object.freeze({ ...props });
+  }
+
+  // リソース名の生成
+  protected generateResourceName(
+    resourceType: string,
+    uniqueName?: string,
+    delimiter: string = "-",
+    pattern: RegExp = /-/g
+  ): string {
+    if (!this.props.systemProperty) {
+      console.log("Unset SystemProperty");
+      throw Error;
+    }
+
+    const resourceName = `${this.props.systemProperty.systemName}${delimiter}${this.props.systemProperty.envName}${delimiter}${resourceType}`;
+    return (
+      uniqueName ? `${resourceName}${delimiter}${uniqueName}` : resourceName
+    ).replace(pattern, delimiter);
+  }
+
+  // Pascal Caseへの変換
+  protected toPascalCase(input: string): string {
+    if (typeof input !== "string") {
+      throw new Error("Input must be a string");
+    }
+
+    try {
+      if (!input) return "";
+
+      return (
+        input
+          // "-", "_" " "で単語ごとに分割
+          .split(/[-_\s]+/)
+          .map((word) => {
+            // 空の単語をスキップ
+            if (!word) return "";
+
+            // 単語を文字配列に分解して処理
+            const chars = word.split("");
+            let prevIsUpper = false;
+
+            // 各文字を処理
+            const processedChars = chars.map((char, index) => {
+              const isUpper = /[A-Z]/.test(char);
+
+              // 最初の文字は大文字に変更
+              if (index === 0) {
+                prevIsUpper = isUpper;
+                return char.toUpperCase();
+              }
+
+              // 現在の文字が大文字で、前の文字も大文字だった場合は小文字に変換
+              if (isUpper && prevIsUpper) {
+                prevIsUpper = true;
+                return char.toLowerCase();
+              }
+
+              // それ以外の場合は元の状態を保持
+              prevIsUpper = isUpper;
+              return char;
+            });
+
+            return processedChars.join("");
+          })
+          .join("")
+      );
+    } catch (error) {
+      console.error("Error converting to PascalCase:", error);
+      throw error;
+    }
+  }
+}

--- a/lib/construct/lambda-construct.ts
+++ b/lib/construct/lambda-construct.ts
@@ -155,7 +155,7 @@ export class LambdaConstruct extends BaseConstruct {
       architecture: cdk.aws_lambda.Architecture.ARM_64,
       timeout: cdk.Duration.seconds(20),
       tracing: cdk.aws_lambda.Tracing.ACTIVE,
-      logRetention: cdk.aws_logs.RetentionDays.ONE_MONTH,
+      logRetention: cdk.aws_logs.RetentionDays.ONE_YEAR,
       loggingFormat: cdk.aws_lambda.LoggingFormat.JSON,
       applicationLogLevelV2: props.functionApplicationLogLevel,
       systemLogLevelV2: props.functionSystemLogLevel,

--- a/lib/construct/lambda-construct.ts
+++ b/lib/construct/lambda-construct.ts
@@ -93,9 +93,6 @@ export class LambdaConstruct extends BaseConstruct {
       assumedBy: new cdk.aws_iam.ServicePrincipal("lambda.amazonaws.com"),
       managedPolicies: [
         cdk.aws_iam.ManagedPolicy.fromAwsManagedPolicyName(
-          "service-role/AWSLambdaBasicExecutionRole"
-        ),
-        cdk.aws_iam.ManagedPolicy.fromAwsManagedPolicyName(
           "service-role/AWSLambdaVPCAccessExecutionRole"
         ),
       ],

--- a/lib/construct/lambda-construct.ts
+++ b/lib/construct/lambda-construct.ts
@@ -164,7 +164,7 @@ export class LambdaConstruct extends BaseConstruct {
         POWERTOOLS_LOG_LEVEL: props.powertoolsLogLevel || "INFO",
         POWERTOOLS_SERVICE_NAME: "monitoring-snapmirror-relationship-health",
         POWERTOOLS_METRICS_NAMESPACE: "ONTAP/SnapMirror",
-        POWERTOOLS_PARAMETERS_MAX_AGE: "500",
+        POWERTOOLS_PARAMETERS_MAX_AGE: "300",
         FSXN_DNS_NAME: props.fsxnDnsName,
         FSXN_USER_NAME: props.fsxnUserName,
         FSXN_USER_CREDENTIAL_SSM_PARAMETER_STORE_NAME:

--- a/lib/construct/lambda-construct.ts
+++ b/lib/construct/lambda-construct.ts
@@ -162,7 +162,7 @@ export class LambdaConstruct extends BaseConstruct {
       layers: [layer, lambdaPowertoolsLayer],
       environment: {
         POWERTOOLS_LOG_LEVEL: props.powertoolsLogLevel || "INFO",
-        POWERTOOLS_SERVICE_NAME: "monitoring-snapmirror-relationship-health",
+        POWERTOOLS_SERVICE_NAME: "monitoring-snapmirror-health",
         POWERTOOLS_METRICS_NAMESPACE: "ONTAP/SnapMirror",
         POWERTOOLS_PARAMETERS_MAX_AGE: "300",
         FSXN_DNS_NAME: props.fsxnDnsName,

--- a/lib/construct/lambda-construct.ts
+++ b/lib/construct/lambda-construct.ts
@@ -45,12 +45,17 @@ export class LambdaConstruct extends BaseConstruct {
           "monitoring-snapmirror-health-lambda"
         )
       : undefined;
-    const policy = new cdk.aws_iam.ManagedPolicy(
+    const policy = new cdk.aws_iam.Policy(
       this,
       "MonitoringSnapMirrorRelationshipHealthPolicy",
       {
-        managedPolicyName: policyName,
+        policyName,
         statements: [
+          new cdk.aws_iam.PolicyStatement({
+            effect: cdk.aws_iam.Effect.ALLOW,
+            resources: ["*"],
+            actions: ["xray:PutTelemetryRecords", "xray:PutTraceSegments"],
+          }),
           new cdk.aws_iam.PolicyStatement({
             effect: cdk.aws_iam.Effect.ALLOW,
             resources: [
@@ -93,13 +98,10 @@ export class LambdaConstruct extends BaseConstruct {
         cdk.aws_iam.ManagedPolicy.fromAwsManagedPolicyName(
           "service-role/AWSLambdaVPCAccessExecutionRole"
         ),
-        cdk.aws_iam.ManagedPolicy.fromAwsManagedPolicyName(
-          "AWSXrayWriteOnlyAccess"
-        ),
-        policy,
       ],
       roleName,
     });
+    role.attachInlinePolicy(policy);
     if (roleName) {
       cdk.Tags.of(role).add("Name", roleName);
     }
@@ -173,6 +175,8 @@ export class LambdaConstruct extends BaseConstruct {
     if (functionName) {
       cdk.Tags.of(lambdaFunction).add("Name", functionName);
     }
+
+    role.node.tryRemoveChild("DefaultPolicy");
 
     this.lambdaFunction = lambdaFunction;
   }

--- a/lib/construct/lambda-construct.ts
+++ b/lib/construct/lambda-construct.ts
@@ -62,11 +62,6 @@ export class LambdaConstruct extends BaseConstruct {
             ],
             actions: ["ssm:GetParameter"],
           }),
-          new cdk.aws_iam.PolicyStatement({
-            effect: cdk.aws_iam.Effect.ALLOW,
-            resources: ["*"],
-            actions: ["cloudwatch:PutMetricData"],
-          }),
         ],
       }
     );

--- a/lib/construct/monitoring-construct.ts
+++ b/lib/construct/monitoring-construct.ts
@@ -1,0 +1,79 @@
+import * as cdk from "aws-cdk-lib";
+import { Construct } from "constructs";
+import { BaseConstructProps, BaseConstruct } from "./base-construct";
+import { MonitoringProperty, SystemProperty } from "../../parameter";
+
+export interface MonitoringConstructProps
+  extends MonitoringProperty,
+    BaseConstructProps {}
+
+export class MonitoringConstruct extends BaseConstruct {
+  private readonly systemProperty?: SystemProperty;
+  private readonly topic: cdk.aws_sns.ITopic;
+  private readonly service: string;
+  private readonly enableOkAction?: boolean;
+  constructor(scope: Construct, id: string, props: MonitoringConstructProps) {
+    super(scope, id, props);
+
+    this.systemProperty = props.systemProperty;
+    this.topic = cdk.aws_sns.Topic.fromTopicArn(this, "Topic", props.topicArn);
+    this.service = props.service;
+    this.enableOkAction = props.enableOkAction;
+
+    props.destinations.forEach((destination) => {
+      this.alarmSnapMirrorRelationshipHealth(
+        destination.svmName,
+        destination.svmUuid
+      );
+    });
+  }
+
+  // SnapMirror relationshipのDestination SVM単位の監視
+  private alarmSnapMirrorRelationshipHealth(
+    destinationStorageVirtualMachineName: string,
+    destinationStorageVirtualMachineUUID: string
+  ): void {
+    const metricName = "SnapMirrorRelationshipHealth";
+    const alarmUniqueName = `${destinationStorageVirtualMachineName}-${metricName}`;
+    const threshold = 1;
+    const evaluationPeriods = 1;
+
+    const alarmName = this.systemProperty
+      ? this.generateResourceName("cw-alarm", alarmUniqueName)
+      : alarmUniqueName;
+
+    const alarm = new cdk.aws_cloudwatch.Alarm(
+      this,
+      `Alarm${this.toPascalCase(alarmUniqueName)}`,
+      {
+        metric: new cdk.aws_cloudwatch.Metric({
+          namespace: "ONTAP/SnapMirror",
+          metricName,
+          dimensionsMap: {
+            DestinationStorageVirtualMachineName:
+              destinationStorageVirtualMachineName,
+            DestinationStorageVirtualMachineUUID:
+              destinationStorageVirtualMachineUUID,
+            service: this.service,
+          },
+          period: cdk.Duration.seconds(300),
+          statistic: "Maximum",
+        }),
+        threshold,
+        evaluationPeriods,
+        comparisonOperator:
+          cdk.aws_cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+        alarmName,
+        treatMissingData: cdk.aws_cloudwatch.TreatMissingData.BREACHING,
+      }
+    );
+
+    cdk.Tags.of(alarm).add("Name", alarmName);
+
+    alarm.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(this.topic));
+
+    if (this.enableOkAction) {
+      alarm.addOkAction(new cdk.aws_cloudwatch_actions.SnsAction(this.topic));
+    }
+  }
+}

--- a/lib/construct/scheduler-construct.ts
+++ b/lib/construct/scheduler-construct.ts
@@ -17,7 +17,7 @@ export class SchedulerConstruct extends BaseConstruct {
     const roleName = props.systemProperty
       ? this.generateResourceName(
           "role",
-          "monitoring-snapmirror-health-scheduler"
+          "monitoring-snapmirror-health-schedule"
         )
       : undefined;
     const role = new cdk.aws_iam.Role(this, "Role", {
@@ -57,10 +57,7 @@ export class SchedulerConstruct extends BaseConstruct {
 
     // EventBridge Scheduler
     const scheduleName = props.systemProperty
-      ? this.generateResourceName(
-          "schedule-group",
-          "monitoring-snapmirror-health"
-        )
+      ? this.generateResourceName("schedule", "monitoring-snapmirror-health")
       : "MonitoringSnapmirrorHealthSchedule";
     const schedule = new cdk.aws_scheduler.CfnSchedule(this, "Default", {
       flexibleTimeWindow: {

--- a/lib/construct/scheduler-construct.ts
+++ b/lib/construct/scheduler-construct.ts
@@ -22,8 +22,8 @@ export class SchedulerConstruct extends BaseConstruct {
       : undefined;
     const role = new cdk.aws_iam.Role(this, "Role", {
       assumedBy: new cdk.aws_iam.ServicePrincipal("scheduler.amazonaws.com"),
-      managedPolicies: [
-        new cdk.aws_iam.ManagedPolicy(this, "InvokeFunction", {
+      inlinePolicies: {
+        InvokeFunction: new cdk.aws_iam.PolicyDocument({
           statements: [
             new cdk.aws_iam.PolicyStatement({
               effect: cdk.aws_iam.Effect.ALLOW,
@@ -32,7 +32,7 @@ export class SchedulerConstruct extends BaseConstruct {
             }),
           ],
         }),
-      ],
+      },
       roleName,
     });
     if (roleName) {

--- a/lib/construct/vpc-endpoint-construct.ts
+++ b/lib/construct/vpc-endpoint-construct.ts
@@ -1,12 +1,15 @@
 import * as cdk from "aws-cdk-lib";
 import { Construct } from "constructs";
+import { BaseConstructProps, BaseConstruct } from "./base-construct";
 import { VpcEndpointProperty } from "../../parameter";
 
-export interface VpcEndpointConstructProps extends VpcEndpointProperty {}
+export interface VpcEndpointConstructProps
+  extends VpcEndpointProperty,
+    BaseConstructProps {}
 
-export class VpcEndpointConstruct extends Construct {
+export class VpcEndpointConstruct extends BaseConstruct {
   constructor(scope: Construct, id: string, props: VpcEndpointConstructProps) {
-    super(scope, id);
+    super(scope, id, props);
 
     // VPC
     const vpc = cdk.aws_ec2.Vpc.fromLookup(this, "Vpc", {

--- a/lib/monitoring-snapmirror-relationship-health-stack.ts
+++ b/lib/monitoring-snapmirror-relationship-health-stack.ts
@@ -19,23 +19,22 @@ export class MonitoringSnapMirrorRelationshipHealthStack extends cdk.Stack {
 
     // VPC Endpoint
     if (props.vpcEndpointProperty) {
-      new VpcEndpointConstruct(
-        this,
-        "VpcEndpointConstruct",
-        props.vpcEndpointProperty
-      );
+      new VpcEndpointConstruct(this, "VpcEndpointConstruct", {
+        systemProperty: props.systemProperty,
+        ...props.vpcEndpointProperty,
+      });
     }
 
     // Lambda
-    const lambdaConstruct = new LambdaConstruct(
-      this,
-      "LambdaConstruct",
-      props.lambdaProperty
-    );
+    const lambdaConstruct = new LambdaConstruct(this, "LambdaConstruct", {
+      systemProperty: props.systemProperty,
+      ...props.lambdaProperty,
+    });
 
     // EventBridge Scheduler
     if (props.schedulerProperty) {
       new SchedulerConstruct(this, "SchedulerConstruct", {
+        systemProperty: props.systemProperty,
         targetFunction: lambdaConstruct.lambdaFunction,
         ...props.schedulerProperty,
       });

--- a/lib/monitoring-snapmirror-relationship-health-stack.ts
+++ b/lib/monitoring-snapmirror-relationship-health-stack.ts
@@ -4,6 +4,7 @@ import { MonitoringSnapMirrorRelationshipHealthProperty } from "../parameter/ind
 import { VpcEndpointConstruct } from "./construct/vpc-endpoint-construct";
 import { LambdaConstruct } from "./construct/lambda-construct";
 import { SchedulerConstruct } from "./construct/scheduler-construct";
+import { MonitoringConstruct } from "./construct/monitoring-construct";
 
 export interface MonitoringSnapMirrorRelationshipHealthStackProps
   extends cdk.StackProps,
@@ -37,6 +38,13 @@ export class MonitoringSnapMirrorRelationshipHealthStack extends cdk.Stack {
         systemProperty: props.systemProperty,
         targetFunction: lambdaConstruct.lambdaFunction,
         ...props.schedulerProperty,
+      });
+    }
+
+    if (props.monitoringProperty) {
+      new MonitoringConstruct(this, "MonitoringConstruct", {
+        systemProperty: props.systemProperty,
+        ...props.monitoringProperty,
       });
     }
   }

--- a/parameter/config/index.ts
+++ b/parameter/config/index.ts
@@ -1,7 +1,9 @@
 import { MonitoringSnapMirrorRelationshipHealthStackProperty } from "../types";
+import { systemConfig } from "./system-config";
 import { vpcEndpointConfig } from "./vpc-endpoint-config";
 import { lambdaConfig } from "./lambda-config";
 import { schedulerConfig } from "./scheduler-config";
+import { tagsConfig } from "./tags-config";
 
 export const monitoringSnapMirrorRelationshipHealthStackProperty: MonitoringSnapMirrorRelationshipHealthStackProperty =
   {
@@ -10,10 +12,12 @@ export const monitoringSnapMirrorRelationshipHealthStackProperty: MonitoringSnap
       region: process.env.CDK_DEFAULT_REGION,
     },
     props: {
+      systemProperty: systemConfig,
       vpcEndpointProperty: vpcEndpointConfig,
       lambdaProperty: lambdaConfig,
       schedulerProperty: schedulerConfig,
     },
+    tags: tagsConfig,
   };
 
 export { vpcEndpointConfig, lambdaConfig, schedulerConfig as scheduleConfig };

--- a/parameter/config/index.ts
+++ b/parameter/config/index.ts
@@ -3,6 +3,7 @@ import { systemConfig } from "./system-config";
 import { vpcEndpointConfig } from "./vpc-endpoint-config";
 import { lambdaConfig } from "./lambda-config";
 import { schedulerConfig } from "./scheduler-config";
+import { monitoringConfig } from "./monitoring-config";
 import { tagsConfig } from "./tags-config";
 
 export const monitoringSnapMirrorRelationshipHealthStackProperty: MonitoringSnapMirrorRelationshipHealthStackProperty =
@@ -16,6 +17,7 @@ export const monitoringSnapMirrorRelationshipHealthStackProperty: MonitoringSnap
       vpcEndpointProperty: vpcEndpointConfig,
       lambdaProperty: lambdaConfig,
       schedulerProperty: schedulerConfig,
+      monitoringProperty: monitoringConfig,
     },
     tags: tagsConfig,
   };

--- a/parameter/config/monitoring-config.ts
+++ b/parameter/config/monitoring-config.ts
@@ -1,0 +1,18 @@
+import { MonitoringProperty } from "../types";
+
+export const monitoringConfig: MonitoringProperty = {
+  destinations: [
+    {
+      svmName: "svm",
+      svmUuid: "3ba0f5ee-6064-11ef-a92a-512f30fadf39",
+    },
+    {
+      svmName: "svm2",
+      svmUuid: "2bb6c4fc-a554-11ef-accd-b31c82a68aa5",
+    },
+  ],
+  service: "monitoring-snapmirror-relationship-health",
+  topicArn:
+    "arn:aws:sns:us-east-1:<123456789012>:non-97-dev-stack-fsxn-resources-MonitoringConstructTopic9E0A8832-D2LGQAtrknkW",
+  enableOkAction: true,
+};

--- a/parameter/config/monitoring-config.ts
+++ b/parameter/config/monitoring-config.ts
@@ -11,7 +11,7 @@ export const monitoringConfig: MonitoringProperty = {
       svmUuid: "2bb6c4fc-a554-11ef-accd-b31c82a68aa5",
     },
   ],
-  service: "monitoring-snapmirror-relationship-health",
+  service: "monitoring-snapmirror-health",
   topicArn:
     "arn:aws:sns:us-east-1:<123456789012>:non-97-dev-stack-fsxn-resources-MonitoringConstructTopic9E0A8832-D2LGQAtrknkW",
   enableOkAction: true,

--- a/parameter/config/system-config.ts
+++ b/parameter/config/system-config.ts
@@ -1,0 +1,6 @@
+import { SystemProperty } from "../types";
+
+export const systemConfig: SystemProperty = {
+  systemName: "non-97",
+  envName: "dev",
+};

--- a/parameter/config/tags-config.ts
+++ b/parameter/config/tags-config.ts
@@ -1,0 +1,16 @@
+import { TagProperty } from "../types";
+
+export const tagsConfig: TagProperty[] = [
+  {
+    key: "SystemName",
+    value: "non-97",
+  },
+  {
+    key: "Env",
+    value: "dev",
+  },
+  {
+    key: "Public",
+    value: "false",
+  },
+];

--- a/parameter/types/index.ts
+++ b/parameter/types/index.ts
@@ -23,7 +23,19 @@ export interface SchedulerProperty {
   scheduleExpression: string;
 }
 
+export interface SystemProperty {
+  systemName: string;
+  envName: string;
+}
+
+export interface TagProperty {
+  key: string;
+
+  value: string;
+}
+
 export interface MonitoringSnapMirrorRelationshipHealthProperty {
+  systemProperty?: SystemProperty;
   vpcEndpointProperty?: VpcEndpointProperty;
   lambdaProperty: LambdaProperty;
   schedulerProperty?: SchedulerProperty;
@@ -32,4 +44,5 @@ export interface MonitoringSnapMirrorRelationshipHealthProperty {
 export interface MonitoringSnapMirrorRelationshipHealthStackProperty {
   env?: cdk.Environment;
   props: MonitoringSnapMirrorRelationshipHealthProperty;
+  tags?: TagProperty[];
 }

--- a/parameter/types/index.ts
+++ b/parameter/types/index.ts
@@ -23,6 +23,16 @@ export interface SchedulerProperty {
   scheduleExpression: string;
 }
 
+export interface MonitoringProperty {
+  destinations: {
+    svmName: string;
+    svmUuid: string;
+  }[];
+  service: string;
+  topicArn: string;
+  enableOkAction?: boolean;
+}
+
 export interface SystemProperty {
   systemName: string;
   envName: string;
@@ -39,6 +49,7 @@ export interface MonitoringSnapMirrorRelationshipHealthProperty {
   vpcEndpointProperty?: VpcEndpointProperty;
   lambdaProperty: LambdaProperty;
   schedulerProperty?: SchedulerProperty;
+  monitoringProperty?: MonitoringProperty;
 }
 
 export interface MonitoringSnapMirrorRelationshipHealthStackProperty {


### PR DESCRIPTION
- 命名規約に従って各種リソースの名前を設定できるように修正
- SnapMirror relationshipのDestination SVM単位のCloudWatch Alarmを追加
- 不要な権限の修正
- Stackの削除保護の有効化